### PR TITLE
Set default network to Mumbai and fix connect/logout buttons

### DIFF
--- a/packages/dapp/src/components/Buttons/ConnectButton.tsx
+++ b/packages/dapp/src/components/Buttons/ConnectButton.tsx
@@ -13,6 +13,7 @@ import React, { useContext } from "react";
 import { AiFillSetting } from "react-icons/ai";
 import { BsFillPersonLinesFill } from "react-icons/bs";
 import { Web3Context } from "../../contexts/Web3Provider";
+import { useActiveWeb3React } from "core/hooks/web3";
 import Address from "../custom/Address";
 
 // const MenuOptions = (logout: any) => (
@@ -45,7 +46,7 @@ import Address from "../custom/Address";
 
 function ConnectButton({ w }: { w?: string }) {
   const { account, connectWeb3, logout } = useContext(Web3Context);
-  const { active } = useWeb3React();
+  const { active } = useActiveWeb3React();
 
   return (
     <HStack w="full">
@@ -58,7 +59,7 @@ function ConnectButton({ w }: { w?: string }) {
             fontSize="18px"
             size="short"
           />
-          {/* <Button onClick={logout}>Logout</Button> */}
+          <Button onClick={logout}>Logout</Button>
           {/* <MenuOptions /> */}
         </>
       ) : active && (

--- a/packages/dapp/src/core/connectors/index.ts
+++ b/packages/dapp/src/core/connectors/index.ts
@@ -59,7 +59,7 @@ export const NETWORK_URLS: { [key in SupportedChainId]: string } = {
 
 export const network = new NetworkConnector({
   urls: NETWORK_URLS,
-  defaultChainId: 1,
+  defaultChainId: 80001,
 });
 
 let networkLibrary: Web3Provider | undefined;


### PR DESCRIPTION
closes #21 

A new user was getting an Unsupported Network error and can't change the network or connect. 

The default network was mainnet (and mainnet is not in our supported networks), so the Connect button doesn't show up for a new user.

I set the default user to Mumbai (we can change it later), uncomment the logout button and fix the connect button.