### PR TITLE
Fix `ens` errors, refactor

### DIFF
--- a/packages/dapp/src/components/custom/Address.tsx
+++ b/packages/dapp/src/components/custom/Address.tsx
@@ -20,8 +20,9 @@ import {
   useDisclosure,
   Text,
 } from "@chakra-ui/react";
-import { useWeb3React } from '@web3-react/core';
+import { useWeb3React } from "@web3-react/core";
 import useCustomColor from "core/hooks/useCustomColor";
+import { useMainnetProvider } from "core/hooks/useMainnetProvider";
 import React, { useContext } from "react";
 import Blockies from "react-blockies";
 import { MdCheckCircle, MdContentCopy } from "react-icons/md";
@@ -55,7 +56,10 @@ function Address({
 }) {
   const { library } = useWeb3React();
   const account = value || address;
-  const ens = useResolveEnsName(library, address);
+  const mainnetProvider = useMainnetProvider(
+    `https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_ID}`
+  );
+  const ens = useResolveEnsName(mainnetProvider, address);
   const { hasCopied, onCopy } = useClipboard(account);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { coloredText } = useCustomColor();

--- a/packages/dapp/src/contexts/Web3Provider.tsx
+++ b/packages/dapp/src/contexts/Web3Provider.tsx
@@ -82,32 +82,15 @@ const Web3Provider = ({ children }: { children: any }) => {
     });
   };
 
-  const setENS = (ens: null | string) => {
-    dispatch({
-      type: "SET_ENS",
-      payload: ens,
-    });
-  };
-
   useEffect(() => {
     async function handleActiveAccount() {
       if (active) {
         setAccount(account);
-        // Get ens
-        let ens = null;
-        try {
-          ens = await library.lookupAddress(account);
-          setENS(ens);
-        } catch (error) {
-          console.log({ error });
-          setENS(null);
-        }
       }
     }
     handleActiveAccount();
     return () => {
       setAccount(null);
-      setENS(null);
     };
   }, [account]);
 
@@ -166,7 +149,11 @@ const Web3Provider = ({ children }: { children: any }) => {
     setAccount(null);
     setContracts(null);
     localStorage.setItem("defaultWallet", "");
-    await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/logout`, {}, { withCredentials: true });
+    await axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL}/logout`,
+      {},
+      { withCredentials: true }
+    );
   };
 
   const connectWeb3 = useCallback(async () => {
@@ -182,13 +169,13 @@ const Web3Provider = ({ children }: { children: any }) => {
     let ens = null;
     try {
       ens = await lib.lookupAddress(account);
-      setENS(ens);
     } catch (error) {
       console.log({ error });
-      setENS(null);
     }
 
-    const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/nonce/${account}`);
+    const { data } = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_URL}/nonce/${account}`
+    );
     const signature = await lib.provider.request({
       method: "personal_sign",
       params: [data.message, account],
@@ -200,7 +187,7 @@ const Web3Provider = ({ children }: { children: any }) => {
       },
       {
         withCredentials: true,
-      },
+      }
     );
     if (verifyResponse.status !== 200) {
       throw new Error("Unauthorized");

--- a/packages/dapp/src/contexts/Web3Reducer.ts
+++ b/packages/dapp/src/contexts/Web3Reducer.ts
@@ -6,7 +6,6 @@ export type State = {
   account?: string;
   chainId?: number;
   provider?: ethers.providers.Web3Provider;
-  ens?: string;
   contracts?: any;
   connectWeb3?: any;
   logout?: any;
@@ -18,11 +17,6 @@ export const Web3Reducer = (state: State, action: Record<string, any>) => {
       return {
         ...state,
         account: action.payload,
-      };
-    case "SET_ENS":
-      return {
-        ...state,
-        ens: action.payload,
       };
     case "SET_PROVIDER":
       return {

--- a/packages/dapp/src/core/hooks/useMainnetProvider.tsx
+++ b/packages/dapp/src/core/hooks/useMainnetProvider.tsx
@@ -1,0 +1,36 @@
+import { StaticJsonRpcProvider } from "@ethersproject/providers";
+import { ethers } from "ethers";
+import { useEffect, useState } from "react";
+
+const createProvider = async (url: string) => {
+  const p = new ethers.providers.StaticJsonRpcProvider(url);
+  await p.ready;
+  return p;
+};
+
+export function useMainnetProvider(
+  url: string
+): ethers.providers.StaticJsonRpcProvider | undefined {
+  const [provider, setProvider] = useState<StaticJsonRpcProvider>();
+
+  useEffect(() => {
+    async function createAndSetProvider() {
+      if (url === "") {
+        return;
+      }
+      if (!url) {
+        console.error("Please pass in a valid RPC url");
+        return;
+      }
+      try {
+        const p = await createProvider(url);
+        setProvider(p);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    createAndSetProvider();
+  }, [url]);
+
+  return provider;
+}


### PR DESCRIPTION
Closes #28 

- Added `useMainnetProvider` hook
- Removed ens from Web3Context because 1. we were not using it, 2. because it wasn't working properly either
- Refactored the `Address` component to use `useMainnetProvider`