### PR TITLE
Sync the mongo/graphql schema with the ceramic schema

### DIFF
--- a/packages/server/graphql/schema.js
+++ b/packages/server/graphql/schema.js
@@ -7,6 +7,15 @@ type Mutation {
     createProfile(data: CreateProfileInput!): Profile!
     updateProfile(data: CreateProfileInput!): Profile!
 }
+type ImageMetadata {
+    src: String
+    size: Int
+    width: Int
+    height: Int
+}
+type Image {
+    original: ImageMetadata
+}
 type Profile {
     tokenId: ID!
     name: String
@@ -20,6 +29,20 @@ type Profile {
     education: [String]
     skills: [String]
     experience: [String]
+    url: String
+    emoji: String
+    image: Image
+    background: Image
+    homeLocation: String
+}
+input ImageMetadataInput {
+    src: String
+    size: Int
+    width: Int
+    height: Int
+}
+input ImageInput {
+    original: ImageMetadataInput
 }
 input CreateProfileInput {
     tokenId: ID!
@@ -34,6 +57,10 @@ input CreateProfileInput {
     education: [String]
     skills: [String]
     experience: [String]
+    url: String
+    emoji: String
+    image: ImageInput
+    homeLocation: String
 }
 `
 


### PR DESCRIPTION
Closes #38 

- [x] BasicProfile
- [ ] PublicProfile
- [ ] PrivateProfile

Couldn't find the schemas for public & private profile on the [Ceramic tiles explorer](https://tiles.ceramic.community/). Am I looking in the wrong place? I am using the `model.json` file stored here on this repo's main branch without any changes.