### PR TITLE
SelfID authentication on each new request

### DIFF
--- a/packages/dapp/src/contexts/Web3Provider.tsx
+++ b/packages/dapp/src/contexts/Web3Provider.tsx
@@ -110,9 +110,30 @@ const Web3Provider = ({ children }: { children: any }) => {
     async function handleActiveAccount() {
       if (active) {
         setAccount(account);
+
+        const authenticatedResponse = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/authenticated`,
+          {
+            withCredentials: true,
+          }
+        );
+
+        if (authenticatedResponse.status === 200 && authenticatedResponse.data.authenticated === true) {
+          const provider = await web3Modal.connect();
+          const mySelf = await SelfID.authenticate({
+            authProvider: new EthereumAuthProvider(provider, account),
+            ceramic: CERAMIC_TESTNET,
+            connectNetwork: CERAMIC_TESTNET,
+            model: modelAliases,
+          });
+
+          setDid(mySelf.id);
+          setMySelf(mySelf);
+        }
       }
     }
     handleActiveAccount();
+
     return () => {
       setAccount(null);
     };


### PR DESCRIPTION
closes #39 

If the user is logged in, the SelfID authentication is made on each new request, so the private ceramic operations are available.