### PR TITLE
Add start script for the dapp at project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "bootstrap": "yarn install; lerna bootstrap;",
-    "start": "lerna run start --parallel"
+    "start": "lerna run start --parallel",
+    "dapp:start": "lerna run dapp:start"
   }
 }

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -15,7 +15,8 @@
     "up-latest": "yarn upgrade-interactive --latest",
     "release": "standard-version",
     "push-release": "git push --follow-tags origin main",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "dapp:start": "yarn start"
   },
   "dependencies": {
     "@3id/connect": "^0.2.5",


### PR DESCRIPTION
We need to have a start script for the dapp at the root for Heroku to be able to run it