### PR TITLE
Add more profile search fields on graphQL

### DIFF
--- a/packages/server/graphql/resolvers/queries/profiles.js
+++ b/packages/server/graphql/resolvers/queries/profiles.js
@@ -2,18 +2,33 @@ const { Profile } = require('../../../models/profile')
 
 const QueryProfiles = {
   profiles: async (_, obj) => {
-    const { limit, skip, name, residenceCountry, skills, search } = obj
+    const { limit, skip, name, residenceCountry, homeLocation, educationInstitution, educationTitle, experienceCompany, experienceTitle, skills, search } = obj
     const filters = {}
     const sort = {}
     const options = { limit, skip }
     if (name) {
-      filters.basicProfile.name = new RegExp(name, 'i')
+      filters['basicProfile.name'] = new RegExp(name, 'i')
     }
     if (residenceCountry) {
-      filters.basicProfile.residenceCountry = residenceCountry
+      filters['basicProfile.residenceCountry'] = residenceCountry
+    }
+    if (homeLocation) {
+      filters['basicProfile.homeLocation'] = homeLocation
     }
     if (skills) {
-      filters.publicProfile.skillTags = { $all: skills }
+      filters['publicProfile.skillTags'] = { $all: skills }
+    }
+    if (educationInstitution) {
+      filters['publicProfile.education.institution'] = new RegExp(educationInstitution, 'i')
+    }
+    if (educationTitle) {
+      filters['publicProfile.education.title'] = new RegExp(educationTitle, 'i')
+    }
+    if (experienceCompany) {
+      filters['publicProfile.experiences.company'] = new RegExp(experienceCompany, 'i')
+    }
+    if (experienceTitle) {
+      filters['publicProfile.experiences.title'] = new RegExp(experienceTitle, 'i')
     }
     if (search) {
       filters.$text = { $search: search }

--- a/packages/server/graphql/schema.js
+++ b/packages/server/graphql/schema.js
@@ -1,7 +1,7 @@
 const schema = `
 type Query {
     profile(tokenId: ID!): Profile!
-    profiles(limit: Int, skip: Int, name: String, residenceCountry: String, skills: [String], search: String): [Profile]!
+    profiles(limit: Int, skip: Int, name: String, residenceCountry: String, homeLocation: String, educationInstitution: String, educationTitle: String, experienceCompany: String, experienceTitle: String, skills: [String], search: String): [Profile]!
 }
 type Mutation {
     createProfile(data: CreateProfileInput!): Profile!


### PR DESCRIPTION
closes #80 

- Fixed search for existing fields.
- Added search fields:

1. homeLocation
2. educationInstitution
3. educationTitle
4. experienceCompany
5. experienceTitle

